### PR TITLE
Documentation & refactoring

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -14,11 +14,15 @@ use bevy::render::{
 use bevy_inspector_egui::{Inspectable, RegisterInspectable};
 use enum_map::{enum_map, Enum, EnumMap};
 
-use crate::{
-    card_spawner::{CardOrigin, OppoCardSpawner, PlayerCardSpawner},
-    war::Value,
-    Participant,
-};
+use crate::{war::Value, CardOrigin, Participant};
+
+/// Component attached to where the opponent draws cards from.
+#[derive(Component)]
+pub struct OppoCardSpawner;
+
+/// Component attached to where the player draws cards from.
+#[derive(Component)]
+pub struct PlayerCardSpawner;
 
 #[cfg_attr(feature = "debug", derive(Inspectable))]
 #[derive(Enum, Clone, Copy, Debug, PartialEq)]

--- a/src/card_effect.rs
+++ b/src/card_effect.rs
@@ -9,15 +9,18 @@ use bevy_debug_text_overlay::screen_print;
 use crate::{
     audio::AudioRequest,
     card::{Card, WordOfPower},
-    card_spawner::{CardOrigin, EndReason, GameOver, GameStarts, PlayedCard},
     cheat::SleeveCard,
-    deck::{OppoDeck, PlayerDeck},
+    deck::{OppoDeckRes, PlayerDeckRes},
     game_ui::EffectEvent,
     pile::{Pile, PileCard, PileType},
     state::{GameState, TurnState},
     war::{BattleOutcome, Value},
-    Participant,
+    CardOrigin, EndReason, GameOver, GameStarts, Participant,
 };
+
+/// Card in the War pile played by the player
+#[derive(Component)]
+pub struct PlayedCard;
 
 pub struct Initiative(Participant);
 impl Initiative {
@@ -217,8 +220,8 @@ pub struct CardStats<'w, 's> {
     piles: Query<'w, 's, (&'static PileCard, &'static Card)>,
     hands: Query<'w, 's, &'static Card, HandFilter>,
     sleeve: Query<'w, 's, &'static Card, With<SleeveCard>>,
-    player_deck: Res<'w, PlayerDeck>,
-    oppo_deck: Res<'w, OppoDeck>,
+    player_deck: Res<'w, PlayerDeckRes>,
+    oppo_deck: Res<'w, OppoDeckRes>,
     score_bonuses: Res<'w, ScoreBonuses>,
 }
 impl<'w, 's> CardStats<'w, 's> {

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -3,14 +3,19 @@ use bevy::prelude::{Plugin as BevyPlugin, *};
 use bevy_debug_text_overlay::screen_print;
 
 use crate::{
-    animate::Animated,
-    card_effect::SeedCount,
-    card_spawner::{
-        BirdPupil, BirdPupilRoot, EndReason, GameOver, GameStarts, GrabbedCard, PlayerSleeve,
-    },
-    game_ui::EffectEvent,
-    state::GameState,
+    animate::Animated, card_effect::SeedCount, game_ui::EffectEvent, player_hand::GrabbedCard,
+    state::GameState, EndReason, GameOver, GameStarts,
 };
+
+#[derive(Component)]
+pub struct BirdPupilRoot;
+
+#[derive(Component)]
+pub struct BirdPupil;
+
+/// Where to stash cards added to sleeve
+#[derive(Component)]
+pub struct PlayerSleeve;
 
 #[derive(Debug)]
 pub enum CheatEvent {

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -3,7 +3,7 @@ use bevy::prelude::{Plugin as BevyPlugin, *};
 use bevy_debug_text_overlay::screen_print;
 
 use crate::{
-    animate::Animated, card_effect::SeedCount, game_ui::EffectEvent, player_hand::GrabbedCard,
+    animate::Animated, game_flow::SeedCount, game_ui::EffectEvent, player_hand::GrabbedCard,
     state::GameState, EndReason, GameOver, GameStarts,
 };
 
@@ -45,8 +45,7 @@ fn use_seed(
     mut ui: EventWriter<EffectEvent>,
     input: Res<Input<KeyCode>>,
 ) {
-    if input.just_pressed(KeyCode::Space) && seed.count() != 0 {
-        assert!(seed.consume());
+    if input.just_pressed(KeyCode::Space) && seed.consume() {
         cheats.send(CheatEvent::ConfuseBird);
         ui.send(EffectEvent::UseSeed);
     }

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -3,11 +3,16 @@ use bevy_scene_hook::SceneHook;
 
 use crate::{
     card::{Card, WordOfPower},
-    card_spawner,
     scene::Scene,
     state::GameState,
     war::Value,
 };
+
+#[derive(Component)]
+pub struct PlayerDeck;
+
+#[derive(Component)]
+pub struct OppoDeck;
 
 struct Deck {
     cards: Vec<Card>,
@@ -70,9 +75,9 @@ macro_rules! cards {
     (@word z) => (Some(WordOfPower::Geh)); // 0 -> 12
 }
 
-pub struct PlayerDeck(Deck);
-impl_deck_methods!(PlayerDeck);
-impl PlayerDeck {
+pub struct PlayerDeckRes(Deck);
+impl_deck_methods!(PlayerDeckRes);
+impl PlayerDeckRes {
     #[rustfmt::skip]
     fn new() -> Self {
         Self(cards![
@@ -86,9 +91,9 @@ impl PlayerDeck {
     }
 }
 
-pub struct OppoDeck(Deck);
-impl_deck_methods!(OppoDeck);
-impl OppoDeck {
+pub struct OppoDeckRes(Deck);
+impl_deck_methods!(OppoDeckRes);
+impl OppoDeckRes {
     #[rustfmt::skip]
     fn new() -> Self {
         Self(cards![
@@ -104,11 +109,11 @@ impl OppoDeck {
 
 // TODO: also change UV
 fn resize_decks(
-    player_parent: Query<&Children, With<card_spawner::PlayerDeck>>,
-    oppo_parent: Query<&Children, With<card_spawner::OppoDeck>>,
+    player_parent: Query<&Children, With<PlayerDeck>>,
+    oppo_parent: Query<&Children, With<OppoDeck>>,
     meshes_q: Query<&Handle<Mesh>>,
-    player_deck: Res<PlayerDeck>,
-    oppo_deck: Res<OppoDeck>,
+    player_deck: Res<PlayerDeckRes>,
+    oppo_deck: Res<OppoDeckRes>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     use bevy::render::mesh::VertexAttributeValues::Float32x3;
@@ -140,13 +145,13 @@ fn resize_decks(
 pub struct Plugin(pub GameState);
 impl BevyPlugin for Plugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(OppoDeck::new())
-            .insert_resource(PlayerDeck::new())
+        app.insert_resource(OppoDeckRes::new())
+            .insert_resource(PlayerDeckRes::new())
             .add_system(resize_decks.with_run_criteria(Scene::when_spawned))
             .add_system_set(
                 SystemSet::on_exit(self.0).with_system(|mut cmds: Commands| {
-                    cmds.insert_resource(OppoDeck::new());
-                    cmds.insert_resource(PlayerDeck::new());
+                    cmds.insert_resource(OppoDeckRes::new());
+                    cmds.insert_resource(PlayerDeckRes::new());
                 }),
             );
     }

--- a/src/game_ui.rs
+++ b/src/game_ui.rs
@@ -8,7 +8,7 @@ use enum_map::{enum_map, EnumMap};
 
 use crate::{
     card::WordOfPower,
-    card_effect::{CardStats, SeedCount},
+    game_flow::{CardStats, SeedCount},
     state::GameState,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,70 +15,13 @@ mod state;
 mod ui;
 mod war;
 
+use state::{GameState, TurnState};
+
 mod camera {
     use bevy::prelude::Component;
 
     #[derive(Component)]
     pub struct PlayerCam;
-}
-// TODO: rename this to reflect content
-mod card_spawner {
-    use super::Participant;
-    use bevy::prelude::Component;
-
-    #[derive(Debug)]
-    pub struct GameOver(pub EndReason);
-    #[derive(Debug)]
-    pub enum EndReason {
-        Victory,
-        Loss,
-        CaughtCheating,
-    }
-
-    #[derive(Default)]
-    pub struct GameStarts(pub u32);
-
-    #[derive(Component)]
-    pub struct PlayerDeck;
-
-    #[derive(Component)]
-    pub struct OppoDeck;
-
-    #[derive(Component)]
-    pub struct GrabbedCard;
-
-    #[derive(Component)]
-    pub struct BirdPupilRoot;
-
-    #[derive(Component)]
-    pub struct BirdPupil;
-
-    /// Card in the War pile played by the player
-    #[derive(Component)]
-    pub struct PlayedCard;
-
-    #[derive(Component)]
-    pub struct CardOrigin(pub Participant);
-
-    /// Component attached to where the opponent draws cards from.
-    #[derive(Component)]
-    pub struct OppoCardSpawner;
-
-    /// Component attached to where the player draws cards from.
-    #[derive(Component)]
-    pub struct PlayerCardSpawner;
-
-    /// Where to stash cards added to sleeve
-    #[derive(Component)]
-    pub struct PlayerSleeve;
-
-    /// Position of the hand of the player
-    #[derive(Component)]
-    pub struct PlayerHand;
-
-    /// Position of the hand of the opposition
-    #[derive(Component)]
-    pub struct OppoHand;
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -87,10 +30,27 @@ pub enum Participant {
     Oppo,
 }
 
+/// Event to trigger a game over.
+#[derive(Debug)]
+pub struct GameOver(pub EndReason);
+
+/// What triggered the game over.
+#[derive(Debug)]
+pub enum EndReason {
+    Victory,
+    Loss,
+    CaughtCheating,
+}
+
+/// How many times did the game get started?
+#[derive(Default)]
+pub struct GameStarts(pub u32);
+
+#[derive(Component)]
+pub struct CardOrigin(pub Participant);
+
 #[derive(Component, Clone)]
 struct WaitScreenRoot;
-
-use state::{GameState, TurnState};
 
 fn main() {
     let mut app = App::new();
@@ -109,7 +69,7 @@ fn main() {
     app.add_plugin(bevy_inspector_egui::WorldInspectorPlugin::new());
 
     app.insert_resource(ClearColor(Color::rgb(0.293, 0.3828, 0.4023)))
-        .init_resource::<card_spawner::GameStarts>()
+        .init_resource::<GameStarts>()
         .add_plugin(bevy_debug_text_overlay::OverlayPlugin::default())
         .add_plugin(player_hand::Plugin(GameState::Playing))
         .add_plugin(oppo_hand::Plugin(GameState::Playing))
@@ -187,7 +147,7 @@ fn setup_load_screen(
 }
 
 fn first_draw(
-    mut starts: ResMut<card_spawner::GameStarts>,
+    mut starts: ResMut<GameStarts>,
     mut game_msgs: EventWriter<game_ui::EffectEvent>,
     mut state: ResMut<State<TurnState>>,
 ) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,9 @@ use bevy::prelude::*;
 mod animate;
 mod audio;
 mod card;
-mod card_effect;
 mod cheat;
 mod deck;
+mod game_flow;
 mod game_ui;
 mod oppo_hand;
 mod pile;
@@ -84,7 +84,7 @@ fn main() {
         .add_plugin(card::Plugin)
         .add_plugin(ui::Plugin)
         .add_plugin(pile::Plugin(GameState::Playing))
-        .add_plugin(card_effect::Plugin(GameState::Playing))
+        .add_plugin(game_flow::Plugin(GameState::Playing))
         .add_plugin(game_ui::Plugin(GameState::Playing))
         .add_system_set(GameState::Playing.on_enter(first_draw))
         .add_system_set(GameState::WaitLoaded.on_enter(setup_load_screen))
@@ -95,7 +95,7 @@ fn main() {
     app.run();
 }
 
-pub(crate) fn cleanup_marked<T: Component>(mut cmds: Commands, query: Query<Entity, With<T>>) {
+pub fn cleanup_marked<T: Component>(mut cmds: Commands, query: Query<Entity, With<T>>) {
     use bevy_debug_text_overlay::screen_print;
     screen_print!(sec: 3.0, "Cleaned up Something (can't show)");
     for entity in query.iter() {

--- a/src/oppo_hand.rs
+++ b/src/oppo_hand.rs
@@ -5,14 +5,17 @@ use fastrand::usize as randusize;
 
 use crate::{
     card::{Card, SpawnCard, WordOfPower},
-    card_effect::ActivateCard,
-    card_spawner::{OppoHand, PlayedCard},
-    deck::OppoDeck,
+    card_effect::{ActivateCard, PlayedCard},
+    deck::OppoDeckRes,
     // pile::{Pile, PileCard, PileType},
     state::{GameState, TurnState},
     war::BattleOutcome,
     Participant,
 };
+
+/// Position of the hand of the opposition
+#[derive(Component)]
+pub struct OppoHand;
 
 #[cfg_attr(feature = "debug", derive(Inspectable))]
 #[derive(Component)]
@@ -25,7 +28,7 @@ impl OppoCard {
     }
 }
 
-fn draw_hand(mut card_spawner: SpawnCard, mut deck: ResMut<OppoDeck>) {
+fn draw_hand(mut card_spawner: SpawnCard, mut deck: ResMut<OppoDeckRes>) {
     for (i, card) in deck.draw(3).into_iter().enumerate() {
         card_spawner
             .spawn_card(card, Participant::Oppo)

--- a/src/oppo_hand.rs
+++ b/src/oppo_hand.rs
@@ -5,9 +5,8 @@ use fastrand::usize as randusize;
 
 use crate::{
     card::{Card, SpawnCard, WordOfPower},
-    card_effect::{ActivateCard, PlayedCard},
     deck::OppoDeckRes,
-    // pile::{Pile, PileCard, PileType},
+    game_flow::{PlayCard, PlayedCard},
     state::{GameState, TurnState},
     war::BattleOutcome,
     Participant,
@@ -41,7 +40,6 @@ fn update_oppo_hand(
     mut cards: Query<(&mut Transform, &OppoCard)>,
     time: Res<Time>,
 ) {
-    // TODO: subtile go up/down hover effect
     let card_speed = 10.0 * time.delta_seconds();
     let hand_transform = oppo_hand.single();
     let hand_pos = hand_transform.translation;
@@ -59,11 +57,9 @@ fn update_oppo_hand(
 
 fn chose_card(
     mut cmds: Commands,
-    mut card_events: EventWriter<ActivateCard>,
+    mut card_events: EventWriter<PlayCard>,
     cards: Query<(Entity, &Card), With<OppoCard>>,
     war_card: Query<&Card, With<PlayedCard>>,
-    // pile_cards: Query<&PileCard>,
-    // pile: Query<&Pile>,
 ) {
     use BattleOutcome::{Loss, Win};
     use WordOfPower::Zihbm;
@@ -100,7 +96,7 @@ fn chose_card(
         }
     };
     cmds.entity(selected).remove::<OppoCard>();
-    card_events.send(ActivateCard::new(selected, Participant::Oppo));
+    card_events.send(PlayCard::new(selected, Participant::Oppo));
 }
 
 pub struct Plugin(pub GameState);

--- a/src/oppo_hand.rs
+++ b/src/oppo_hand.rs
@@ -106,10 +106,11 @@ fn chose_card(
 pub struct Plugin(pub GameState);
 impl BevyPlugin for Plugin {
     fn build(&self, app: &mut App) {
+        use crate::system_helper::EasySystemSetCtor;
         #[cfg(feature = "debug")]
         app.register_inspectable::<OppoCard>();
-        app.add_system_set(SystemSet::on_enter(TurnState::Draw).with_system(draw_hand))
-            .add_system_set(SystemSet::on_enter(TurnState::Oppo).with_system(chose_card))
-            .add_system_set(SystemSet::on_update(self.0).with_system(update_oppo_hand));
+        app.add_system_set(TurnState::Draw.on_enter(draw_hand))
+            .add_system_set(TurnState::Oppo.on_enter(chose_card))
+            .add_system_set(self.0.on_update(update_oppo_hand));
     }
 }

--- a/src/pile.rs
+++ b/src/pile.rs
@@ -29,7 +29,6 @@ pub struct Pile {
     pub which: PileType,
 }
 impl Pile {
-    // TODO: account for Participant when throwing into the war pile
     pub fn additional_card(&mut self) -> PileCard {
         let Self { stack_size, which } = *self;
         self.stack_size += 1;
@@ -66,10 +65,8 @@ fn move_to_pile(
 ) {
     let card_speed = 10.0 * time.delta_seconds();
     for (mut transform, PileCard { offset, stack_pos, which }) in cards.iter_mut() {
-        let (pile_transform, _) = pile
-            .iter()
-            .find(|p| &p.1.which == which)
-            .expect("Pile exists");
+        let msg = "Pile exists";
+        let (pile_transform, _) = pile.iter().find(|p| &p.1.which == which).expect(msg);
         let pile_pos = pile_transform.translation;
         let target = pile_pos + offset.translation + Vec3::Y * 0.012 * *stack_pos as f32;
         let origin = transform.translation;

--- a/src/player_hand.rs
+++ b/src/player_hand.rs
@@ -13,9 +13,9 @@ use crate::{
     audio::AudioRequest::{self, PlayShuffleLong, PlayShuffleShort},
     camera::PlayerCam,
     card::{Card, CardStatus, SpawnCard},
-    card_effect::ActivateCard,
     cheat::{CheatEvent, SleeveCard},
     deck::PlayerDeckRes,
+    game_flow::PlayCard,
     state::{GameState, TurnState},
     Participant,
 };
@@ -109,7 +109,7 @@ fn update_raycast(
     }
 }
 
-/// Set the [`HoveredCard`] as the last one on which the cursor hovered.
+/// Set the [`HoverStatus`] of cards
 fn select_card(
     mut cursor: EventReader<CursorMoved>,
     hand_raycaster: Query<&RayCastSource<HandRaycast>>,
@@ -146,7 +146,7 @@ enum HandEvent {
 fn play_card(
     mouse: Res<Input<MouseButton>>,
     hand_raycaster: Query<&RayCastSource<HandRaycast>>,
-    mut card_events: EventWriter<ActivateCard>,
+    mut card_events: EventWriter<PlayCard>,
     mut cmds: Commands,
     mut hand_cards: Query<(Entity, &mut Card, &mut HandCard, &mut Transform)>,
     mut hand_events: EventWriter<HandEvent>,
@@ -182,7 +182,7 @@ fn play_card(
                     card.set_status(CardStatus::Normal);
                     cmds.entity(entity).remove::<HandCard>();
                     cmds.entity(entity).remove::<RayCastMesh<HandRaycast>>();
-                    card_events.send(ActivateCard::new(entity, Participant::Player));
+                    card_events.send(PlayCard::new(entity, Participant::Player));
                 } else {
                     hand_card.hover = HoverStatus::None;
                 }

--- a/src/player_hand.rs
+++ b/src/player_hand.rs
@@ -14,12 +14,18 @@ use crate::{
     camera::PlayerCam,
     card::{Card, CardStatus, SpawnCard},
     card_effect::ActivateCard,
-    card_spawner::{GrabbedCard, PlayerHand},
     cheat::{CheatEvent, SleeveCard},
-    deck::PlayerDeck,
+    deck::PlayerDeckRes,
     state::{GameState, TurnState},
     Participant,
 };
+
+/// Position of the hand of the player
+#[derive(Component)]
+pub struct PlayerHand;
+
+#[derive(Component)]
+pub struct GrabbedCard;
 
 enum HandRaycast {}
 
@@ -50,7 +56,7 @@ impl HandCard {
 struct DrawParams<'w, 's> {
     card_spawner: SpawnCard<'w, 's>,
     meshes: ResMut<'w, Assets<Mesh>>,
-    deck: ResMut<'w, PlayerDeck>,
+    deck: ResMut<'w, PlayerDeckRes>,
     audio: EventWriter<'w, 's, AudioRequest>,
 }
 impl<'w, 's> DrawParams<'w, 's> {

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -42,11 +42,6 @@ impl SceneHook for Scene {
     }
 }
 
-#[derive(Default)]
-pub struct ScenePreload {
-    pub game: Handle<bevy::prelude::Scene>,
-}
-
 fn load_scene(
     mut cmds: Commands,
     mut scene_spawner: ResMut<SceneSpawner>,

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -7,11 +7,12 @@ use bevy_scene_hook::{SceneHook, SceneInstance};
 use crate::{
     animate::Animated,
     camera::PlayerCam,
-    card_spawner::{
-        BirdPupil, BirdPupilRoot, OppoCardSpawner, OppoDeck, OppoHand, PlayerCardSpawner,
-        PlayerDeck, PlayerHand, PlayerSleeve,
-    },
+    card::{OppoCardSpawner, PlayerCardSpawner},
+    cheat::{BirdPupil, BirdPupilRoot, PlayerSleeve},
+    deck::{OppoDeck, PlayerDeck},
+    oppo_hand::OppoHand,
     pile::{Pile, PileType},
+    player_hand::PlayerHand,
 };
 
 pub enum Scene {}

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,6 +9,10 @@ pub enum GameState {
     RestartMenu,
 }
 
+// LEAD: potential improvement: logic in game_flow really does not care for the
+// distinction between player turn and oppo turn, we might be able to merge
+// Oppo and Player
+/// In-game game state, see the diagram in [`crate::game_flow`] for flow chart.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub enum TurnState {
     /// Game just started
@@ -19,10 +23,8 @@ pub enum TurnState {
     New,
     /// Player's turn to play a card
     Player,
-    /// Player has played a card
-    PlayerActivated,
     /// Oppo's turn to select a card
     Oppo,
-    /// Oppo has played his card
-    OppoActivated,
+    /// A participants has played a card
+    CardPlayed,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@
 pub enum GameState {
     MainMenu,
     /// Wait until the game scene is fully loaded if not already
-    WaitSceneLoaded,
+    WaitLoaded,
     /// The game is running
     Playing,
     /// Restart menu after gameover

--- a/src/system_helper.rs
+++ b/src/system_helper.rs
@@ -1,0 +1,19 @@
+use bevy::ecs::schedule::{IntoSystemDescriptor, StateData};
+use bevy::prelude::*;
+
+pub trait EasySystemSetCtor {
+    fn on_update<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet;
+    fn on_enter<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet;
+    fn on_exit<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet;
+}
+impl<St: StateData> EasySystemSetCtor for St {
+    fn on_update<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet {
+        SystemSet::on_update(self).with_system(system)
+    }
+    fn on_exit<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet {
+        SystemSet::on_exit(self).with_system(system)
+    }
+    fn on_enter<Params>(self, system: impl IntoSystemDescriptor<Params>) -> SystemSet {
+        SystemSet::on_enter(self).with_system(system)
+    }
+}

--- a/src/ui/main_menu.rs
+++ b/src/ui/main_menu.rs
@@ -115,7 +115,7 @@ fn update_menu(
                     Ok(MainMenuElem::Start) => {
                         screen_print!("Player pressed the start button");
                         audio_requests.send(AudioRequest::PlayWoodClink(SfxParam::PlayOnce));
-                        game_state.set(GameState::WaitSceneLoaded).unwrap();
+                        game_state.set(GameState::WaitLoaded).unwrap();
                     }
                     Ok(MainMenuElem::LockMouse) => {
                         let window = windows.get_primary_mut().expect(window_msg);
@@ -290,9 +290,10 @@ fn setup_main_menu(mut cmds: Commands, menu_assets: Res<MenuAssets>, ui_assets: 
 pub struct Plugin(pub GameState);
 impl BevyPlugin for Plugin {
     fn build(&self, app: &mut App) {
+        use crate::system_helper::EasySystemSetCtor;
         app.init_resource::<MenuAssets>()
-            .add_system_set(SystemSet::on_enter(self.0).with_system(setup_main_menu))
-            .add_system_set(SystemSet::on_exit(self.0).with_system(cleanup_marked::<MainMenuRoot>))
+            .add_system_set(self.0.on_enter(setup_main_menu))
+            .add_system_set(self.0.on_exit(cleanup_marked::<MainMenuRoot>))
             .add_system_set(
                 SystemSet::on_update(self.0)
                     .with_system(update_sliders)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,12 +7,13 @@ pub use common::UiAssets as Assets;
 use bevy::prelude::{Plugin as BevyPlugin, *};
 
 use crate::GameState;
+
 #[cfg(feature = "debug")]
 fn debug_buttons(
     mut ctx: ResMut<bevy_inspector_egui::bevy_egui::EguiContext>,
-    mut events: EventWriter<crate::card_spawner::GameOver>,
+    mut events: EventWriter<crate::GameOver>,
 ) {
-    use crate::card_spawner::{EndReason, GameOver};
+    use crate::{EndReason, GameOver};
     use bevy_inspector_egui::egui::*;
     Area::new("gameover::debug_buttons")
         .anchor(Align2::RIGHT_BOTTOM, vec2(0., 0.))

--- a/src/ui/restart_menu.rs
+++ b/src/ui/restart_menu.rs
@@ -4,11 +4,7 @@ use bevy::prelude::*;
 use bevy_ui_build_macros::{build_ui, size, style, unit};
 use bevy_ui_navigation::{Focusable, NavEvent, NavRequest};
 
-use crate::{
-    card_spawner::{EndReason, GameOver},
-    cleanup_marked,
-    state::GameState,
-};
+use crate::{cleanup_marked, state::GameState, EndReason, GameOver};
 
 struct RestartAssets {
     defeat: Handle<Image>,

--- a/src/ui/restart_menu.rs
+++ b/src/ui/restart_menu.rs
@@ -113,12 +113,10 @@ fn continue_on_space(mut keys: ResMut<Input<KeyCode>>, mut state: ResMut<State<G
 pub struct Plugin;
 impl bevy::app::Plugin for Plugin {
     fn build(&self, app: &mut App) {
+        use crate::system_helper::EasySystemSetCtor;
         app.init_resource::<RestartAssets>().add_event::<GameOver>();
         app.add_system(handle_gameover_event);
-        app.add_system_set(
-            SystemSet::on_exit(GameState::RestartMenu)
-                .with_system(cleanup_marked::<RestartMenuRoot>),
-        );
+        app.add_system_set(GameState::RestartMenu.on_exit(cleanup_marked::<RestartMenuRoot>));
         app.add_system_set(
             SystemSet::on_update(GameState::RestartMenu)
                 .with_system(update)


### PR DESCRIPTION
* Add `SystemSet` helper
* Rename `card_effect` to `game_flow`
* Major documentation addition to `game_flow`
* Remove `card_spawner`, spreading the things it defining to their relevant files
* Cleanup commented code in oppo_hand
* Merge `PlayerActivated` and `OppoActivated` TurnState variants
* Rename `ActivateCard` to `PlayCard`
* Rename `handle_activated` to `handle_played`
* Remove publicity qualifier on cleanup_marked
* Remove unused `ScenePreload`

This solves #26