### PR TITLE
Gameplay discoverability improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "warlocks-gambit"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "warlocks-gambit"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,14 @@ The game was developped in seven days for the first bevy game jam.
 
 You can play it at https://gibonus.itch.io/warlocks-gambit
 
+## Documentation
+
+The crate is relatively well documented. The documentation is meant to be
+explored using `rustdoc`, so please clone locally this repository and run
+`cargo doc --document-private-items --open` to get access to the
+documentation.
+
+
 ## License
 
 ### Assets

--- a/assets/scene.glb
+++ b/assets/scene.glb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:050588353b1ec7c842e2ce1a25ad88388c07449c7ffdc83f9c93ef2e51e356d5
-size 5393284
+oid sha256:7a2feae47a7e2e32d1de3be7a1a928952c596a84d6f6348bfd67cacc75a7d648
+size 5393304

--- a/assets/scene_debug.glb
+++ b/assets/scene_debug.glb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fb1bcb38858e8feca574feae79b5f6accbf7e9246d444671187ad0e7c2e0d7d
-size 13960

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -12,7 +12,7 @@ use bevy_debug_text_overlay::screen_print;
 
 use crate::{
     animate::Animated, game_flow::SeedCount, game_ui::EffectEvent, player_hand::GrabbedCard,
-    state::GameState, EndReason, GameOver, GameStarts,
+    state::GameState, EndReason, GameOver,
 };
 
 #[derive(Component)]
@@ -94,14 +94,12 @@ fn update_sleeve_transform(
 }
 
 fn execute_cheat(
-    game_starts: Res<GameStarts>,
     mut bird_eye: Query<&mut Animated, With<BirdPupilRoot>>,
     mut gameover_events: EventWriter<GameOver>,
     mut ui: EventWriter<EffectEvent>,
     mut watch: ResMut<BirdEye>,
     mut cmds: Commands,
     mut events: EventReader<CheatEvent>,
-    mut tuto_shown: Local<bool>,
 ) {
     for event in events.iter() {
         match event {
@@ -109,10 +107,6 @@ fn execute_cheat(
                 watch.is_watching = false;
                 if let Ok(mut anim) = bird_eye.get_single_mut() {
                     *anim = Animated::Circle { radius: 0.1, period: 1.0, offset: 0.0 };
-                }
-                if game_starts.0 == 2 && !*tuto_shown {
-                    *tuto_shown = true;
-                    ui.send(EffectEvent::TutoSleeve);
                 }
             }
             CheatEvent::HideInSleeve(_) if watch.is_watching => {

--- a/src/cheat.rs
+++ b/src/cheat.rs
@@ -43,8 +43,14 @@ impl Default for BirdEye {
     }
 }
 
-fn cleanup(mut bird_eye: ResMut<BirdEye>) {
+fn cleanup(
+    mut bird_eye: ResMut<BirdEye>,
+    mut bird_eye_anim: Query<&mut Animated, With<BirdPupilRoot>>,
+) {
     *bird_eye = BirdEye::default();
+    if let Ok(mut bird_eye_anim) = bird_eye_anim.get_single_mut() {
+        *bird_eye_anim = Animated::Static;
+    }
 }
 
 fn use_seed(

--- a/src/game_flow.rs
+++ b/src/game_flow.rs
@@ -226,7 +226,11 @@ fn handle_turn_end(
 
     let war_pile: Vec<_> = played_cards.iter().collect();
 
-    let mut add_card_to_pile = |entity, card: &Card, bonus, who: Participant| {
+    let mut send_score_update = |who, score| {
+        score_update.send(ScoreEvent::Add(who, score));
+    };
+
+    let mut add_card_to_pile = |entity, bonus, who: Participant| {
         let is_war = |p: &Mut<Pile>| p.which == PileType::War;
         let is_who = |p: &Mut<Pile>| p.which == who.into();
 
@@ -235,8 +239,8 @@ fn handle_turn_end(
             .insert(pile.add_existing(entity))
             .remove::<PlayedCard>();
         piles.iter_mut().find(is_war).unwrap().remove(entity);
-        score_update.send(ScoreEvent::Add(who, bonus + card.value as i32));
         score_bonuses.add_to_owner(who, bonus);
+        bonus
     };
     match war_pile[..] {
         [card1, card2] => {
@@ -246,16 +250,22 @@ fn handle_turn_end(
             screen_print!(sec: 2, "player: {player_bonus}, oppo: {oppo_bonus}");
             match player.1.beats(oppo.1) {
                 BattleOutcome::Tie => {
-                    add_card_to_pile(player.2, player.1, player_bonus, Player);
-                    add_card_to_pile(oppo.2, oppo.1, oppo_bonus, Oppo);
+                    let p1_bonus = add_card_to_pile(player.2, player_bonus, Player);
+                    let p2_bonus = add_card_to_pile(oppo.2, oppo_bonus, Oppo);
+                    send_score_update(Player, p1_bonus + player.1.value_i32());
+                    send_score_update(Oppo, p2_bonus + oppo.1.value_i32());
                 }
                 BattleOutcome::Loss => {
-                    add_card_to_pile(player.2, player.1, player_bonus, Oppo);
-                    add_card_to_pile(oppo.2, oppo.1, oppo_bonus, Oppo);
+                    let p1_bonus = add_card_to_pile(player.2, player_bonus, Oppo);
+                    let p2_bonus = add_card_to_pile(oppo.2, oppo_bonus, Oppo);
+                    let cards_value = player.1.value_i32() + oppo.1.value_i32();
+                    send_score_update(Oppo, p1_bonus + p2_bonus + cards_value);
                 }
                 BattleOutcome::Win => {
-                    add_card_to_pile(player.2, player.1, player_bonus, Player);
-                    add_card_to_pile(oppo.2, oppo.1, oppo_bonus, Player);
+                    let p1_bonus = add_card_to_pile(player.2, player_bonus, Player);
+                    let p2_bonus = add_card_to_pile(oppo.2, oppo_bonus, Player);
+                    let cards_value = player.1.value_i32() + oppo.1.value_i32();
+                    send_score_update(Player, p1_bonus + p2_bonus + cards_value);
                 }
             }
         }

--- a/src/game_flow.rs
+++ b/src/game_flow.rs
@@ -99,7 +99,7 @@ use crate::{
     pile::{Pile, PileCard, PileType},
     state::{GameState, TurnState},
     war::{BattleOutcome, Card, WordOfPower::Egeq},
-    CardOrigin, EndReason, GameOver, GameStarts, Participant,
+    CardOrigin, EndReason, GameOver, Participant,
 };
 
 /// Cards in the War pile
@@ -182,8 +182,6 @@ fn handle_played(
     mut turn: ResMut<State<TurnState>>,
     mut seed_count: ResMut<SeedCount>,
     mut audio_events: EventWriter<AudioRequest>,
-    mut tuto_shown: Local<bool>,
-    game_starts: Res<GameStarts>,
     cards: Query<&Card>,
 ) {
     use PileType::War;
@@ -195,15 +193,10 @@ fn handle_played(
         let card_word = cards.get(*card).map(|c| c.word);
         audio_events.send(AudioRequest::PlayShuffleLong);
         if let Ok(Some(word)) = card_word {
-            // TODO: spawn clouds of smoke
             ui_events.send(EffectEvent::Show(word));
             audio_events.send(AudioRequest::PlayWord(word));
         }
         if let Ok(Some(Egeq)) = card_word {
-            if game_starts.0 == 2 && !*tuto_shown {
-                *tuto_shown = true;
-                ui_events.send(EffectEvent::TutoUseSeed);
-            }
             seed_count.0 += 1;
         }
         turn.set(TurnState::CardPlayed).unwrap();

--- a/src/game_ui.rs
+++ b/src/game_ui.rs
@@ -46,18 +46,15 @@ impl FromWorld for UiAssets {
 }
 
 fn spawn_game_ui(mut cmds: Commands, ui_assets: Res<UiAssets>) {
-    let text = |content: &str| {
+    let text_sized = |content: &str, font_size| {
         let color = Color::NAVY;
         let horizontal = HorizontalAlign::Left;
-        let style = TextStyle {
-            color,
-            font: ui_assets.font.clone(),
-            font_size: 60.0,
-        };
+        let style = TextStyle { color, font: ui_assets.font.clone(), font_size };
         let align = TextAlignment { horizontal, ..Default::default() };
         let text = Text::with_section(content, style, align);
         TextBundle { text, ..Default::default() }
     };
+    let text = |content: &str| text_sized(content, 60.0);
     let node = NodeBundle {
         color: Color::NONE.into(),
         style: style! {
@@ -86,7 +83,8 @@ fn spawn_game_ui(mut cmds: Commands, ui_assets: Res<UiAssets>) {
                 align_items: AlignItems::FlexEnd
             }[;Name::new("game ui right column")](
                 node[; Name::new("Seeds")](
-                    node[text("Seeds: ");],
+                    node[text_sized("(space to use)", 30.0);],
+                    node[text("Seeds:");],
                     node[text("0"); UiInfo::Seeds]
                 ),
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod cheat;
 mod deck;
 mod game_flow;
 mod game_ui;
+mod numbers;
 mod oppo_hand;
 mod pile;
 mod player_hand;
@@ -29,6 +30,14 @@ use state::{GameState, TurnState};
 pub enum Participant {
     Player,
     Oppo,
+}
+impl Participant {
+    pub fn color(&self) -> Color {
+        match self {
+            Participant::Player => Color::rgb_u8(77, 77, 208),
+            Participant::Oppo => Color::RED,
+        }
+    }
 }
 
 /// Event to trigger a game over.
@@ -78,6 +87,7 @@ fn main() {
 
     app.insert_resource(ClearColor(Color::rgb(0.293, 0.3828, 0.4023)))
         .init_resource::<GameStarts>()
+        .add_plugin(numbers::Plugin)
         .add_plugin(bevy_debug_text_overlay::OverlayPlugin::default())
         .add_plugin(player_hand::Plugin(GameState::Playing))
         .add_plugin(oppo_hand::Plugin(GameState::Playing))

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,10 +52,6 @@ pub enum EndReason {
     CaughtCheating,
 }
 
-/// How many times did the game get started?
-#[derive(Default)]
-pub struct GameStarts(pub u32);
-
 #[derive(Component)]
 pub struct CardOrigin(pub Participant);
 
@@ -86,7 +82,6 @@ fn main() {
         });
 
     app.insert_resource(ClearColor(Color::rgb(0.293, 0.3828, 0.4023)))
-        .init_resource::<GameStarts>()
         .add_plugin(numbers::Plugin)
         .add_plugin(bevy_debug_text_overlay::OverlayPlugin::default())
         .add_plugin(player_hand::Plugin(GameState::Playing))
@@ -157,14 +152,6 @@ fn setup_load_screen(
     }
 }
 
-fn first_draw(
-    mut starts: ResMut<GameStarts>,
-    mut game_msgs: EventWriter<game_ui::EffectEvent>,
-    mut state: ResMut<State<TurnState>>,
-) {
-    if starts.0 == 1 {
-        game_msgs.send(game_ui::EffectEvent::TutoGetSeed);
-    }
-    starts.0 += 1;
+fn first_draw(mut state: ResMut<State<TurnState>>) {
     state.set(TurnState::Draw).unwrap();
 }

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -52,6 +52,7 @@ type SpriteComponents = (
     &'static mut Visibility,
     &'static mut Handle<StandardMaterial>,
 );
+#[allow(clippy::type_complexity)]
 fn display_number(
     numbers: Query<&Number, Or<(Changed<Children>, Changed<Number>)>>,
     mut sprites: Query<SpriteComponents, With<NumberSprite>>,

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -53,7 +53,7 @@ type SpriteComponents = (
     &'static mut Handle<StandardMaterial>,
 );
 fn display_number(
-    numbers: Query<&Number, Changed<Number>>,
+    numbers: Query<&Number, Or<(Changed<Children>, Changed<Number>)>>,
     mut sprites: Query<SpriteComponents, With<NumberSprite>>,
     assets: Res<NumberAssets>,
     mut mats: ResMut<Assets<StandardMaterial>>,

--- a/src/numbers.rs
+++ b/src/numbers.rs
@@ -1,0 +1,140 @@
+//! Display numbers in the 3d game world.
+use std::iter;
+
+use bevy::{
+    prelude::{Plugin as BevyPlugin, *},
+    utils::HashMap,
+};
+#[cfg(feature = "debug")]
+use bevy_inspector_egui::{Inspectable, RegisterInspectable};
+
+#[cfg_attr(feature = "debug", derive(Inspectable))]
+#[derive(Component)]
+pub struct Number {
+    pub value: i32,
+    pub color: Color,
+}
+impl Number {
+    pub fn new(value: i32, color: Color) -> Self {
+        Self { value, color }
+    }
+}
+
+#[derive(Component)]
+struct NumberSprite;
+
+#[rustfmt::skip]
+const NUMBER_NAMES: [&str; 10] = 
+    [ "Zero", "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine"];
+
+fn add_number(
+    new_numbers: Query<Entity, Added<Number>>,
+    mut cmds: Commands,
+    assets: Res<NumberAssets>,
+) {
+    for entity in new_numbers.iter() {
+        cmds.entity(entity).with_children(|cmds| {
+            for _ in 0..5 {
+                cmds.spawn_bundle((NumberSprite, Name::new("NumberSprite")))
+                    .insert_bundle(PbrBundle {
+                        mesh: assets.quad.clone(),
+                        visibility: Visibility { is_visible: false },
+                        ..Default::default()
+                    });
+            }
+        });
+    }
+}
+
+type SpriteComponents = (
+    &'static Parent,
+    &'static mut Transform,
+    &'static mut Visibility,
+    &'static mut Handle<StandardMaterial>,
+);
+fn display_number(
+    numbers: Query<&Number, Changed<Number>>,
+    mut sprites: Query<SpriteComponents, With<NumberSprite>>,
+    assets: Res<NumberAssets>,
+    mut mats: ResMut<Assets<StandardMaterial>>,
+) {
+    let mut decimal_streams: HashMap<Entity, _> = HashMap::default();
+    for (Parent(parent), mut transform, mut vis, mut material) in sprites.iter_mut() {
+        // We only do things for numbers which value changed
+        if let Ok(Number { value, color }) = numbers.get(*parent) {
+            let initial_iter = || decimals(*value).enumerate();
+            let current_decimal = decimal_streams.entry(*parent).or_insert_with(initial_iter);
+            if let Some((i, current)) = current_decimal.next() {
+                vis.is_visible = true;
+                transform.translation.x = i as f32 * -0.9;
+                *material = mats.add(StandardMaterial {
+                    base_color_texture: Some(assets.images[current].clone()),
+                    alpha_mode: AlphaMode::Mask(0.5),
+                    emissive: *color,
+                    ..Default::default()
+                });
+            } else {
+                vis.is_visible = false;
+            }
+        }
+    }
+}
+
+/// The right-to-left decimal values of number.
+fn decimals(mut number: i32) -> impl Iterator<Item = usize> {
+    iter::from_fn(move || {
+        let current = number % 10;
+        let is_nonzero = number != 0;
+        number = (number - current) / 10;
+        is_nonzero.then(|| current as usize)
+    })
+}
+
+struct NumberAssets {
+    images: [Handle<Image>; 10],
+    quad: Handle<Mesh>,
+}
+impl FromWorld for NumberAssets {
+    fn from_world(world: &mut World) -> Self {
+        let images = world.get_resource::<Assets<Image>>().unwrap();
+        let images = NUMBER_NAMES.map(|name| images.get_handle(format!("cards/Value{name}.png")));
+        let mut meshes = world.get_resource_mut::<Assets<Mesh>>().unwrap();
+        let quad = meshes.add(shape::Quad::new(Vec2::new(1., 2.)).into());
+        Self { images, quad }
+    }
+}
+
+pub struct Plugin;
+impl BevyPlugin for Plugin {
+    fn build(&self, app: &mut App) {
+        #[cfg(feature = "debug")]
+        app.register_inspectable::<Number>();
+
+        app.init_resource::<NumberAssets>()
+            .add_system(display_number)
+            .add_system(add_number);
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decimals() {
+        macro_rules! number_assert {
+            ($initial:expr, $( $result:literal)*) => (
+                let mut result: Vec<usize> = decimals($initial).collect();
+                let expected: Vec<usize> = vec![$($result,)*];
+                result.reverse();
+                assert_eq!(result, expected);
+            )
+        }
+        number_assert!(10000, 1 0 0 0 0);
+        number_assert!(10203, 1 0 2 0 3);
+        number_assert!(12, 1 2);
+        number_assert!(10, 1 0);
+        number_assert!(93841345, 9 3 8 4 1 3 4 5);
+        number_assert!(1, 1);
+        number_assert!(0,);
+    }
+}

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -3,6 +3,7 @@
 use std::f32::consts::TAU;
 
 use bevy::{
+    math::EulerRot::XYZ,
     pbr::wireframe::Wireframe,
     prelude::{Plugin as BevyPlugin, *},
 };
@@ -14,9 +15,12 @@ use crate::{
     card::{OppoCardSpawner, PlayerCardSpawner},
     cheat::{BirdPupil, BirdPupilRoot, PlayerSleeve},
     deck::{Deck, DeckAssets, OppoDeck, PlayerDeck},
+    game_ui::{OppoScore, PlayerScore},
+    numbers::Number,
     oppo_hand::OppoHand,
     pile::{Pile, PileType},
     player_hand::{CardCollisionAssets, HandDisengageArea, HandRaycast, PlayerHand, SleeveArea},
+    Participant,
 };
 
 pub enum Scene {}
@@ -85,8 +89,36 @@ impl WorldSceneHook for Scene {
             "OppoHand" => cmds.insert_bundle((OppoHand, Animated::bob(1.0, 0.3, 6.0))),
             "PlayerHand" => cmds.insert_bundle((PlayerHand, Animated::bob(2.0, 0.05, 7.0))),
             "Pile" => cmds.insert(Pile::new(PileType::War)),
-            "OppoPile" => cmds.insert(Pile::new(PileType::Oppo)),
-            "PlayerPile" => cmds.insert(Pile::new(PileType::Player)),
+            "OppoPile" => cmds
+                .insert(Pile::new(PileType::Oppo))
+                .with_children(|cmds| {
+                    cmds.spawn_bundle((
+                        Name::new("Oppo score"),
+                        OppoScore,
+                        Number::new(0, Participant::Oppo.color()),
+                        Transform {
+                            translation: Vec3::Z,
+                            rotation: Quat::from_euler(XYZ, TAU / 4., 0.5, 0.0),
+                            scale: Vec3::splat(0.3),
+                        },
+                        GlobalTransform::default(),
+                    ));
+                }),
+            "PlayerPile" => cmds
+                .insert(Pile::new(PileType::Player))
+                .with_children(|cmds| {
+                    cmds.spawn_bundle((
+                        Name::new("Player score"),
+                        PlayerScore,
+                        Number::new(0, Participant::Player.color()),
+                        Transform {
+                            translation: Vec3::Z,
+                            rotation: Quat::from_euler(XYZ, TAU / 4., -1.1, 0.0),
+                            scale: Vec3::splat(0.3),
+                        },
+                        GlobalTransform::default(),
+                    ));
+                }),
             "ManBody" => cmds.insert(Animated::breath(0.0, 0.03, 6.0)),
             "ManHead" => cmds.insert(Animated::bob(6. / 4., 0.1, 6.0)),
             "Bird" => cmds.insert(Animated::breath(0.0, 0.075, 5.0)),

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -137,12 +137,7 @@ fn load_scene(
     mut scene_spawner: ResMut<SceneSpawner>,
     asset_server: Res<AssetServer>,
 ) {
-    let scene_name = if cfg!(feature = "debug") {
-        "scene_debug.glb#Scene0"
-    } else {
-        "scene.glb#Scene0"
-    };
-    let scene = scene_spawner.spawn(asset_server.load(scene_name));
+    let scene = scene_spawner.spawn(asset_server.load("scene.glb#Scene0"));
     cmds.spawn().insert(SceneInstance::<Scene>::new(scene));
 }
 

--- a/src/ui/restart_menu.rs
+++ b/src/ui/restart_menu.rs
@@ -63,6 +63,7 @@ fn handle_gameover_event(
 
         let focusable = Focusable::default();
         let cursor = MenuCursor::spawn_ui_element(&mut commands);
+        let defeat_hint = "Having difficulties? The game rules are in the main menu.";
         build_ui! {
             #[cmd(commands)]
             node{ size: size!(100 pct, 100 pct) }[;Name::new("Restart Menu root"), RestartMenuRoot](
@@ -74,7 +75,16 @@ fn handle_gameover_event(
                 ],
                 node[; Name::new("Menu columns")](
                     entity[image; style! { size: size!(auto, 45 pct), }],
-                    entity[ui_assets.large_text(continue_text);],
+                    entity[
+                        ui_assets.large_text(continue_text);
+                        style! { margin: rect!(0 px, 0 px, 0 px, 60 px,), }
+                    ],
+                    if (matches!(*reason, Loss | CaughtCheating)) {
+                        entity[
+                            ui_assets.text_bundle(defeat_hint, 30.0);
+                            style! { margin: rect!(0 px, 0 px, 0 px, 30 px,), }
+                        ]
+                    },
                     entity[ui_assets.large_text("Main menu"); focusable, MainMenu],
                     if (cfg!(target_arch = "wasm32")) {
                         entity[ui_assets.large_text("(Press space to restart)");]

--- a/src/ui/restart_menu.rs
+++ b/src/ui/restart_menu.rs
@@ -1,7 +1,7 @@
 use super::common::{MenuCursor, UiAssets};
 use bevy::app::AppExit;
 use bevy::prelude::*;
-use bevy_ui_build_macros::{build_ui, size, style, unit};
+use bevy_ui_build_macros::{build_ui, rect, size, style, unit};
 use bevy_ui_navigation::{Focusable, NavEvent, NavRequest};
 
 use crate::{cleanup_marked, state::GameState, EndReason, GameOver};
@@ -23,6 +23,7 @@ impl FromWorld for RestartAssets {
 
 #[derive(Component, Clone)]
 enum Button {
+    MainMenu,
     Restart,
     ExitApp,
 }
@@ -37,14 +38,14 @@ fn handle_gameover_event(
     mut state: ResMut<State<GameState>>,
     mut events: EventReader<GameOver>,
 ) {
-    use self::Button::{ExitApp, Restart};
+    use self::Button::{ExitApp, MainMenu, Restart};
     use EndReason::{CaughtCheating, Loss, Victory};
     if let Some(GameOver(reason)) = events.iter().next() {
         state.set(GameState::RestartMenu).unwrap();
         let continue_text = match *reason {
-            Victory => "Congratulation! Replay?",
-            Loss => "You couldn't make up the point difference! Try again?",
-            CaughtCheating => "You got caught cheating! Try again?",
+            Victory => "Congratulation! You won!",
+            Loss => "You couldn't make up the point difference!",
+            CaughtCheating => "The BIRD saw you cheating!",
         };
         let won = matches!(*reason, Victory);
         let image = if won { &assets.victory } else { &assets.defeat };
@@ -74,6 +75,7 @@ fn handle_gameover_event(
                 node[; Name::new("Menu columns")](
                     entity[image; style! { size: size!(auto, 45 pct), }],
                     entity[ui_assets.large_text(continue_text);],
+                    entity[ui_assets.large_text("Main menu"); focusable, MainMenu],
                     if (cfg!(target_arch = "wasm32")) {
                         entity[ui_assets.large_text("(Press space to restart)");]
                     } else {
@@ -97,7 +99,8 @@ fn update(
             match buttons.get(*from.first()) {
                 Ok(Button::Restart) => state.set(GameState::Playing).unwrap(),
                 Ok(Button::ExitApp) => app_exit.send(AppExit),
-                _ => (),
+                Ok(Button::MainMenu) => state.set(GameState::MainMenu).unwrap(),
+                Err(_) => (),
             }
         }
     }

--- a/src/war.rs
+++ b/src/war.rs
@@ -213,7 +213,7 @@ impl Card {
         }
     }
     pub fn max_value(&self) -> i32 {
-        let value = self.value as i32;
+        let value = self.value_i32();
         let word_max_bonus = match self.word {
             // Zero = 12
             Some(WordOfPower::Geh) => 12,
@@ -232,9 +232,12 @@ impl Card {
         let zero_bonus = |c| is_zero(c) * zero_bonus;
         let mul_bonus = is_word(self, Qube) + is_word(other, Qube);
         (
-            zero_bonus(self) * (mul_bonus + 1) + self.value as i32 * mul_bonus,
-            zero_bonus(other) * (mul_bonus + 1) + other.value as i32 * mul_bonus,
+            zero_bonus(self) * (mul_bonus + 1) + self.value_i32() * mul_bonus,
+            zero_bonus(other) * (mul_bonus + 1) + other.value_i32() * mul_bonus,
         )
+    }
+    pub fn value_i32(&self) -> i32 {
+        self.value as i32
     }
 }
 #[cfg(test)]


### PR DESCRIPTION
* Put scores on top of the score piles, show how many points a specific turn earned.
* Add a lame in-game manual and refer to it when player loses.
* Enable player to go back to the main menu.
* Display card effect description **before** playing it.